### PR TITLE
Fixed double snapshot check

### DIFF
--- a/Plugins/20 Desktop/10 Automated Pool Desktop Wrong Snapshot.ps1
+++ b/Plugins/20 Desktop/10 Automated Pool Desktop Wrong Snapshot.ps1
@@ -8,7 +8,7 @@ $poolname=$pool.base.name
 if ($pool.type -like "*automated*" -AND $pool.source -like "*VIEW_COMPOSER*"){
 
 $poolmachines=get-hvmachine ($pool.base.name)
-$wrongsnaps=$poolmachines | where {$_.managedmachinedata.viewcomposerdata.baseimagesnapshotpath -notlike  $pool.automateddesktopdata.VirtualCenternamesdata.snapshotpath -OR $_.managedmachinedata.viewcomposerdata.baseimagesnapshotpath -notlike $pool.automateddesktopdata.VirtualCenternamesdata.snapshotpath}
+$wrongsnaps=$poolmachines | where {$_.managedmachinedata.viewcomposerdata.baseimagesnapshotpath -notlike  $pool.automateddesktopdata.VirtualCenternamesdata.snapshotpath -OR $_.managedmachinedata.viewcomposerdata.baseimagepath -notlike $pool.automateddesktopdata.VirtualCenternamesdata.parentvmpath}
 foreach ($wrongsnap in $wrongsnaps){
 $wrongsnapdesktops+= New-Object PSObject -Property @{"VM Name" = $wrongsnap.base.name;
 								"VM Snapshot" = $wrongsnap.managedmachinedata.viewcomposerdata.baseimagesnapshotpath;
@@ -26,5 +26,5 @@ $Header = "VDI Desktops based on wrong snapshot"
 $Comments = "These desktops have not been recomposed with the correct Golden Image Snapshot"
 $Display = "Table"
 $Author = "Wouter Kursten"
-$PluginVersion = 0.1
+$PluginVersion = 0.2
 $PluginCategory = "View"

--- a/Plugins/30 Pods/00 Pod Health.ps1
+++ b/Plugins/30 Pods/00 Pod Health.ps1
@@ -1,6 +1,6 @@
 # Start of Settings
 # End of Settings
-$pods=$services1.pod.pod_list() | where {$_. localpod -eq $false}
+$pods=$services1.pod.pod_list() | where {$_.localpod -eq $false}
 $podhealth=@()
 foreach ($pod in $pods) {
 	$endpoints=$services1.podhealth.podhealth_get($pod.id).data.endpointhealth
@@ -21,5 +21,5 @@ $Header = "VDI Remote Pod Health"
 $Comments = "This is the check to see if all Pod Communications are ok"
 $Display = "Table"
 $Author = "Wouter Kursten"
-$PluginVersion = 0.1
+$PluginVersion = 0.1.1
 $PluginCategory = "View"


### PR DESCRIPTION
It did twice the same in the OR. Fixed this to check both the parentvm path and the snapshot path